### PR TITLE
0.7 dev reload

### DIFF
--- a/cloudify_tf/tasks.py
+++ b/cloudify_tf/tasks.py
@@ -130,14 +130,15 @@ def destroy(ctx, tf, **_):
 
 @operation
 @with_terraform
-def reload(ctx, tf, source, **_):
+def reload(ctx, tf, source, destory_prev_resources, **_):
     """
     Terraform reload plan given new location as input
     """
     try:
         # check the new path provided by input
         if source:
-            tf.destroy()
+            if destory_prev_resources:
+                tf.destroy()
             # clear the runtime properties to fetch new template
             ctx.instance.runtime_properties.pop('terraform_source', None)
             ctx.instance.runtime_properties.pop('last_source_location', None)

--- a/cloudify_tf/tasks.py
+++ b/cloudify_tf/tasks.py
@@ -23,7 +23,8 @@ from cloudify.decorators import operation
 from cloudify.utils import exception_to_error_cause
 
 from terraform import Terraform
-from utils import get_terraform_source
+from utils import ( get_terraform_source, get_terraform_state_file,
+                    move_state_file )
 
 
 def with_terraform(func):
@@ -129,40 +130,63 @@ def destroy(ctx, tf, **_):
 
 
 @operation
-@with_terraform
-def reload(ctx, tf, source, destory_prev_resources, **_):
+def reload(ctx, source, destroy_previous, **_):
     """
     Terraform reload plan given new location as input
     """
     try:
-        # check the new path provided by input
         if source:
-            if destory_prev_resources:
-                tf.destroy()
-            # clear the runtime properties to fetch new template
+            resource_config = ctx.node.properties['resource_config']
+            executable_path = ctx.node.properties['executable_path']
+            plugins_dir = ctx.node.properties['plugins_dir']
+            if not os.path.exists(executable_path):
+                raise NonRecoverableError(
+                    "Terraform's executable not found in {0}. Please set the "
+                    "'executable_path' property accordingly.".format(
+                        executable_path))
+            state_file = None
+            # if we want to destroy previous: no need to preserve the state file
+            # by default the state file will be used if no remote backend
+            if destroy_previous:
+                with get_terraform_source(ctx, resource_config) as terraform_source:
+                    tf = Terraform(
+                        ctx.logger,
+                        executable_path,
+                        plugins_dir,
+                        terraform_source,
+                        variables=resource_config.get('variables'),
+                        environment_variables=resource_config.get('environment_variables'))
+                    tf.destroy()
+            else:
+                # extract the state file from previous stored source
+                state_file = get_terraform_state_file(ctx)
+            # initialize new location to apply terraform
             ctx.instance.runtime_properties.pop('terraform_source', None)
             ctx.instance.runtime_properties.pop('last_source_location', None)
             ctx.node.properties['resource_config']['source'] = source
+            resource_config = ctx.node.properties['resource_config']
+            with get_terraform_source(ctx, resource_config) as terraform_source:
+                tf = Terraform(
+                    ctx.logger,
+                    executable_path,
+                    plugins_dir,
+                    terraform_source,
+                    variables=resource_config.get('variables'),
+                    environment_variables=resource_config.get('environment_variables'))
+                tf.init()
+                if state_file:
+                    move_state_file(state_file, terraform_source)
+                tf.plan()
+                tf.apply()
+                tf_state = tf.state_pull()
+                refresh_resources_properties(ctx, tf_state)
         else:
             raise NonRecoverableError(
-                "New source path/URL for Terraform template was not provided")
-        # initialize Terraform with new template location
-        resource_config = ctx.node.properties['resource_config']
-        with get_terraform_source(ctx, resource_config) as terraform_source:
-            tf = Terraform(
-                ctx.logger,
-                tf.binary_path,
-                tf.plugins_dir,
-                terraform_source,
-                variables=resource_config.get('variables'),
-                environment_variables=resource_config.get('environment_variables'))
-            tf.init()
-            tf.plan()
-            tf.apply()
-            tf_state = tf.state_pull()
-            refresh_resources_properties(ctx, tf_state)
+            "New source path/URL for Terraform template was not provided")
+
+
     except Exception as ex:
-        _, _, tb = sys.exc_info()
-        raise NonRecoverableError(
-            "Failed reloading terraform plan",
-            causes=[exception_to_error_cause(ex, tb)])
+      _, _, tb = sys.exc_info()
+      raise NonRecoverableError(
+          "Failed reloading terraform plan",
+          causes=[exception_to_error_cause(ex, tb)])

--- a/cloudify_tf/tasks.py
+++ b/cloudify_tf/tasks.py
@@ -184,9 +184,8 @@ def reload(ctx, source, destroy_previous, **_):
             raise NonRecoverableError(
             "New source path/URL for Terraform template was not provided")
 
-
     except Exception as ex:
-      _, _, tb = sys.exc_info()
-      raise NonRecoverableError(
-          "Failed reloading terraform plan",
-          causes=[exception_to_error_cause(ex, tb)])
+        _, _, tb = sys.exc_info()
+        raise NonRecoverableError(
+            "Failed destroying",
+            causes=[exception_to_error_cause(ex, tb)])

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -89,7 +89,7 @@ node_types:
             source:
               type: string
               default: { get_attribute: [ SELF, last_source_location ] }
-            destory_prev_resources:
+            destroy_previous:
               type: boolean
               default: false
         refresh:

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -89,6 +89,9 @@ node_types:
             source:
               type: string
               default: { get_attribute: [ SELF, last_source_location ] }
+            destory_prev_resources:
+              type: boolean
+              default: false
         refresh:
           # Refreshes Terraform's state.
           implementation: tf.cloudify_tf.tasks.state_pull


### PR DESCRIPTION
1. Remove the decorator from reload function -because it override the `terraform_source` to be the old extracted source -
2. Added a simple logic to extract and copy the state file to extracted location of the newly provided source, in case of we don't want to destroy previous resources and keep track of changes 