### PR TITLE
0.7 dev reload

### DIFF
--- a/cloudify_tf/tasks.py
+++ b/cloudify_tf/tasks.py
@@ -130,14 +130,15 @@ def destroy(ctx, tf, **_):
 
 @operation
 @with_terraform
-def reload(ctx, tf, source, **_):
+def reload(ctx, tf, source, destory_prev_resources, **_):
     """
     Terraform reload plan given new location as input
     """
     try:
         # check the new path provided by input
         if source:
-            tf.destroy()
+            if destory_prev_resources:
+                tf.destroy()
             # clear the runtime properties to fetch new template
             ctx.instance.runtime_properties.pop('terraform_source', None)
             ctx.instance.runtime_properties.pop('last_source_location', None)

--- a/cloudify_tf/tasks.py
+++ b/cloudify_tf/tasks.py
@@ -23,7 +23,8 @@ from cloudify.decorators import operation
 from cloudify.utils import exception_to_error_cause
 
 from terraform import Terraform
-from utils import get_terraform_source
+from utils import ( get_terraform_source, get_terraform_state_file,
+                    move_state_file )
 
 
 def with_terraform(func):
@@ -129,40 +130,63 @@ def destroy(ctx, tf, **_):
 
 
 @operation
-@with_terraform
-def reload(ctx, tf, source, destory_prev_resources, **_):
+def reload(ctx, source, destroy_previous, **_):
     """
     Terraform reload plan given new location as input
     """
     try:
-        # check the new path provided by input
         if source:
-            if destory_prev_resources:
-                tf.destroy()
-            # clear the runtime properties to fetch new template
+            resource_config = ctx.node.properties['resource_config']
+            executable_path = ctx.node.properties['executable_path']
+            plugins_dir = ctx.node.properties['plugins_dir']
+            if not os.path.exists(executable_path):
+                raise NonRecoverableError(
+                    "Terraform's executable not found in {0}. Please set the "
+                    "'executable_path' property accordingly.".format(
+                        executable_path))
+            state_file = None
+            # if we want to destroy previous: no need to preserve the state file
+            # by default the state file will be used if no remote backend
+            if destroy_previous:
+                with get_terraform_source(ctx, resource_config) as terraform_source:
+                    tf = Terraform(
+                        ctx.logger,
+                        executable_path,
+                        plugins_dir,
+                        terraform_source,
+                        variables=resource_config.get('variables'),
+                        environment_variables=resource_config.get('environment_variables'))
+                    tf.destroy()
+            else:
+                # extract the state file from previous stored source
+                state_file = get_terraform_state_file(ctx)
+            # initialize new location to apply terraform
             ctx.instance.runtime_properties.pop('terraform_source', None)
             ctx.instance.runtime_properties.pop('last_source_location', None)
             ctx.node.properties['resource_config']['source'] = source
+            resource_config = ctx.node.properties['resource_config']
+            with get_terraform_source(ctx, resource_config) as terraform_source:
+                tf = Terraform(
+                    ctx.logger,
+                    executable_path,
+                    plugins_dir,
+                    terraform_source,
+                    variables=resource_config.get('variables'),
+                    environment_variables=resource_config.get('environment_variables'))
+                tf.init()
+                if state_file:
+                    move_state_file(state_file, terraform_source)
+                tf.plan()
+                tf.apply()
+                tf_state = tf.state_pull()
+                refresh_resources_properties(ctx, tf_state)
         else:
             raise NonRecoverableError(
-                "New source path/URL for Terraform template was not provided")
-        # initialize Terraform with new template location
-        resource_config = ctx.node.properties['resource_config']
-        with get_terraform_source(ctx, resource_config) as terraform_source:
-            tf = Terraform(
-                ctx.logger,
-                tf.binary_path,
-                tf.plugins_dir,
-                terraform_source,
-                variables=resource_config.get('variables'),
-                environment_variables=resource_config.get('environment_variables'))
-            tf.init()
-            tf.plan()
-            tf.apply()
-            tf_state = tf.state_pull()
-            refresh_resources_properties(ctx, tf_state)
+            "New source path/URL for Terraform template was not provided")
+
+
     except Exception as ex:
-        _, _, tb = sys.exc_info()
-        raise NonRecoverableError(
-            "Failed reloading terraform plan",
-            causes=[exception_to_error_cause(ex, tb)])
+      _, _, tb = sys.exc_info()
+      raise NonRecoverableError(
+          "Failed reloading terraform plan",
+          causes=[exception_to_error_cause(ex, tb)])

--- a/cloudify_tf/tasks.py
+++ b/cloudify_tf/tasks.py
@@ -184,9 +184,8 @@ def reload(ctx, source, destroy_previous, **_):
             raise NonRecoverableError(
             "New source path/URL for Terraform template was not provided")
 
-
     except Exception as ex:
-      _, _, tb = sys.exc_info()
-      raise NonRecoverableError(
-          "Failed reloading terraform plan",
-          causes=[exception_to_error_cause(ex, tb)])
+        _, _, tb = sys.exc_info()
+        raise NonRecoverableError(
+            "Failed destroying",
+            causes=[exception_to_error_cause(ex, tb)])

--- a/cloudify_tf/tasks.py
+++ b/cloudify_tf/tasks.py
@@ -187,5 +187,5 @@ def reload(ctx, source, destroy_previous, **_):
     except Exception as ex:
         _, _, tb = sys.exc_info()
         raise NonRecoverableError(
-            "Failed destroying",
+            "Failed reloading Terraform plan",
             causes=[exception_to_error_cause(ex, tb)])

--- a/cloudify_tf/utils.py
+++ b/cloudify_tf/utils.py
@@ -20,6 +20,7 @@ import threading
 import zipfile
 import os
 from io import BytesIO
+from tempfile import mkstemp
 import StringIO
 import shutil
 import time
@@ -27,6 +28,8 @@ import time
 import requests
 
 from . import TERRAFORM_BACKEND
+
+TERRAFORM_STATE_FILE="terraform.tfstate"
 
 
 def unzip_archive(ctx, archive_path, storage_path, **_):
@@ -146,15 +149,15 @@ def get_terraform_state_file(ctx):
     with tempfile.NamedTemporaryFile(delete=False) as f:
         base64.decode(StringIO.StringIO(encoded_source), f)
         terraform_source_zip = f.name
-    storage_path = ctx.node.properties['storage_path'] or None
+    storage_path = ctx.node.properties.get('storage_path')
     if storage_path and not os.path.isdir(storage_path):
         os.makedirs(storage_path)
     extracted_source = unzip_archive(ctx, terraform_source_zip, storage_path)
     os.remove(terraform_source_zip)
     for dir_name, subdirs, filenames in os.walk(extracted_source):
         for filename in filenames:
-            if filename == 'terraform.tfstate':
-                state_file_path = "/tmp/terraform.tfstate_{0}".format(int(round(time.time() * 1000)))
+            if filename == TERRAFORM_STATE_FILE:
+                fd, state_file_path = mkstemp()
                 shutil.move(os.path.join(dir_name, filename), state_file_path)
                 break
     shutil.rmtree(extracted_source)
@@ -162,7 +165,7 @@ def get_terraform_state_file(ctx):
 
 
 def move_state_file(src, dst):
-    shutil.move(src, os.path.join(dst, "terraform.tfstate"))
+    shutil.move(src, os.path.join(dst, TERRAFORM_STATE_FILE))
 
 
 def create_backend_string(name, options):

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -89,7 +89,7 @@ node_types:
             source:
               type: string
               default: { get_attribute: [ SELF, last_source_location ] }
-            destory_prev_resources:
+            destroy_previous:
               type: boolean
               default: false
         refresh:

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -89,6 +89,9 @@ node_types:
             source:
               type: string
               default: { get_attribute: [ SELF, last_source_location ] }
+            destory_prev_resources:
+              type: boolean
+              default: false
         refresh:
           # Refreshes Terraform's state.
           implementation: tf.cloudify_tf.tasks.state_pull


### PR DESCRIPTION
1. Remove the decorator from reload function -because it override `terraform_source` to be the old extracted source -
2. Added a simple logic to extract and copy the state file from `terraform_source` to the extracted location of newly provided source, in case we don't want to destroy previous resources and keep track of changes